### PR TITLE
Feat/team

### DIFF
--- a/src/main/java/org/example/taskflowd/domain/team/entity/TeamMember.java
+++ b/src/main/java/org/example/taskflowd/domain/team/entity/TeamMember.java
@@ -19,10 +19,6 @@ public class TeamMember extends BaseEntity {
     private Long id;
 
     @Id
-    private UUID idPk;
-
-    private UUID idPk2;
-
     private Long userId;
 
     private String role;
@@ -34,9 +30,8 @@ public class TeamMember extends BaseEntity {
     private Team team;
 
     // 생성자
-    public TeamMember(Long id, UUID idPk, Long userId, String role) {
+    public TeamMember(Long id, Long userId, String role) {
         this.id = id;
-        this.idPk = idPk;
         this.userId = userId;
         this.role = role;
     }
@@ -44,7 +39,6 @@ public class TeamMember extends BaseEntity {
     // 편의 생성자
     public TeamMember(Team team, Long userId, String role) {
         this.id = team.getId();
-        this.idPk = team.getIdPk(); // Team의 UUID 사용
         this.userId = userId;
         this.role = role;
         this.team = team;

--- a/src/main/java/org/example/taskflowd/domain/team/entity/TeamMemberId.java
+++ b/src/main/java/org/example/taskflowd/domain/team/entity/TeamMemberId.java
@@ -13,5 +13,5 @@ import java.util.UUID;
 @EqualsAndHashCode
 public class TeamMemberId implements Serializable {
     private Long id;
-    private UUID idPk;
+    private Long userId;
 }

--- a/src/main/java/org/example/taskflowd/domain/team/service/TeamMemberService.java
+++ b/src/main/java/org/example/taskflowd/domain/team/service/TeamMemberService.java
@@ -22,7 +22,6 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class TeamMemberService {
 
     private final TeamRepository teamRepository;

--- a/src/main/java/org/example/taskflowd/domain/team/service/TeamMemberService.java
+++ b/src/main/java/org/example/taskflowd/domain/team/service/TeamMemberService.java
@@ -52,9 +52,9 @@ public class TeamMemberService {
         // 팀 멤버 존재 확인
         TeamMember teamMember = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
                 .orElseThrow(() -> new GlobalException(TeamErrorCode.MEMBER_NOT_FOUND));
-
-
-        teamMember.delete();
+        team.removeMember(teamMember);
+        teamMember.delete();//삭제표시로 요청
+        teamMemberRepository.save(teamMember); //삭제한것으로 해달라고 부탁
         return convertToTeamResponse(team);
     }
 

--- a/src/main/java/org/example/taskflowd/domain/team/service/TeamService.java
+++ b/src/main/java/org/example/taskflowd/domain/team/service/TeamService.java
@@ -73,7 +73,7 @@ public class TeamService {
     @Transactional
     public void deleteTeam(Long teamId) {
         Team team = findTeamById(teamId);
-        team.delete(); // BaseEntity의 soft delete
+        teamRepository.delete(team);
     }
 
     // 팀 멤버 목록 조회

--- a/src/main/java/org/example/taskflowd/domain/team/service/TeamService.java
+++ b/src/main/java/org/example/taskflowd/domain/team/service/TeamService.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class TeamService {
 
     private final TeamRepository teamRepository;


### PR DESCRIPTION

1. 문제 발생 :rotating_light:
한 팀에 여러 명의 팀 멤버를 추가할 때, 기존 멤버의 데이터가 덮어쓰여지는 현상 발생
addMember() 메서드를 실행하면 새로운 멤버가 추가되지 않고, 기존 멤버의 정보가 방금 추가하려는 멤버의 정보로 변경되었습니다.
데이터베이스에 INSERT 쿼리가 아닌 UPDATE 쿼리가 실행되는 것을 확인했습니다.
2. 원인 분석 :male-detective:
JPA의 복합 키 설정 오류로 인한 엔티티 중복 인식
불완전한 복합 키 구성: TeamMember 엔티티는 @IdClass를 사용해 id와 idPk를 복합 키로 사용하고 있었습니다. 하지만 TeamMemberId.java 파일을 확인한 결과, id와 idPk는 팀(Team) 엔티티의 ID와 UUID를 그대로 복사해서 사용하고 있었습니다.
userId 필드의 누락: '철수'와 '영희'는 서로 다른 userId를 가졌지만, 복합 키(TeamMemberId.java)에 userId가 포함되지 않았습니다. JPA는 userId를 엔티티의 고유성을 식별하는 키로 인식하지 못했습니다.
JPA의 잘못된 판단: (팀 ID, 팀 UUID)라는 동일한 복합 키를 가진 두 개의 엔티티가 들어오자, JPA는 이를 동일한 엔티티로 판단하여 INSERT 대신 UPDATE 쿼리를 실행했습니다.
3. 해결 방안 :white_check_mark:
복합 키를 논리적으로 올바르게 수정하여 엔티티의 고유성 보장
TeamMemberId.java 수정: 복합 키를 (id, userId) 조합으로 변경했습니다. 팀과 팀 멤버 간의 관계를 명확하게 정의하는 논리적 키인 userId를 복합 키에 포함시켰습니다.
수정 전: private Long id; private UUID idPk;
수정 후: private Long id; private Long userId;
TeamMember.java 수정: idPk 필드와 관련된 모든 코드를 제거하고, @Id 어노테이션을 id와 userId 필드에 부여하여 복합 키를 JPA가 올바르게 인식하도록 설정했습니다.
수정 전: private Long id; private UUID idPk; private UUID idPk2;
수정 후: private Long id; private Long userId;
결과: 이제 JPA는 (팀 ID, 유저 ID)라는 고유한 복합 키를 기준으로 엔티티를 식별하게 됩니다. 따라서 새로운 팀 멤버가 추가될 때마다 다른 복합 키를 가지게 되어 데이터가 덮어쓰여지지 않고, 새로운 행으로 올바르게 삽입됩니다.
정리: 이 문제는 userId가 다르더라도 복합 키에 포함되지 않아 JPA가 이를 무시하고 UPDATE를 실행했기 때문에 발생했습니다. 복합 키의 구성 요소를 (팀 ID, 유저 ID)로 올바르게 수정함으로써 각 팀 멤버의 고유성을 보장하고 문제를 해결했습니다.